### PR TITLE
Enable account lockout on failed login attempts

### DIFF
--- a/ParaglidingFlightLogWeb/ParaglidingFlightLogWeb/Components/Account/Pages/Login.razor
+++ b/ParaglidingFlightLogWeb/ParaglidingFlightLogWeb/Components/Account/Pages/Login.razor
@@ -83,7 +83,7 @@
     {
         // This doesn't count login failures towards account lockout
         // To enable password failures to trigger account lockout, set lockoutOnFailure: true
-        var result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
+        var result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: true);
         if (result.Succeeded)
         {
             Logger.LogInformation("User logged in.");


### PR DESCRIPTION
Changed PasswordSignInAsync to set lockoutOnFailure to true, so failed login attempts now contribute to account lockout, improving security against brute-force attacks.